### PR TITLE
Fixing target platform to include org.json

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.json.parsers/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.json.parsers/pom.xml
@@ -22,20 +22,4 @@
 
   <packaging>eclipse-plugin</packaging>
 
-	<dependencies>
-		<dependency>
-			<groupId>de.twentyeleven.skysail</groupId>
-			<artifactId>org.json-osgi</artifactId>
-			<version>20080701</version>
-		</dependency>
-		<!--
-		<dependency>
-			<groupId>org.json</groupId>
-			<artifactId>json</artifactId>
-			<version>20141113</version>
-		</dependency>
-		-->
-	</dependencies>
-
-
 </project>

--- a/targetplatform/smarthome.target
+++ b/targetplatform/smarthome.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="SmartHome" sequenceNumber="85">
+<?pde version="3.8"?><target name="SmartHome" sequenceNumber="86">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="com.google.inject" version="3.0.0.v201312141243"/>
@@ -55,6 +55,7 @@
 <unit id="org.codehaus.jackson.mapper.source" version="1.6.0.v20101005-0925"/>
 <unit id="org.hamcrest.core" version="1.3.0.v201303031735"/>
 <unit id="org.hamcrest.core.source" version="1.3.0.v201303031735"/>
+<unit id="org.json" version="1.0.0.v201011060100"/>
 <unit id="org.mockito" version="1.9.5.v201311280930"/>
 <unit id="org.mockito.source" version="1.9.5.v201311280930"/>
 <unit id="org.objectweb.asm" version="5.0.1.v201404251740"/>
@@ -78,7 +79,6 @@
 <unit id="org.slf4j.log4j" version="1.7.2.v20130115-1340"/>
 <unit id="org.slf4j.log4j.source" version="1.7.2.v20130115-1340"/>
 <unit id="org.apache.felix.gogo.runtime" version="0.10.0.v201209301036"/>
-<unit id="org.json" version="1.0.0"/>
 <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20140525021250/repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
@@ -124,10 +124,6 @@
 <unit id="com.eclipsesource.jaxrs.jersey.runtime.feature.feature.group" version="0.0.0"/>
 <unit id="com.eclipsesource.jaxrs.provider.sse.feature.feature.group" version="0.0.0"/>
 <repository location="http://hstaudacher.github.io/osgi-jax-rs-connector/4.2.0"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.json-osgi" version="20080701"/>
-<repository location="http://repo1.maven.org/maven2"/>
 </location>
 </locations>
 </target>


### PR DESCRIPTION
With this fix, all automation bundles correctly compile in the workspace.
