### PR TITLE
When removing RuleProviders the corresponding rules should be removed from RuleRegistry #84

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/internal/core/ManagedRuleProvider.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/internal/core/ManagedRuleProvider.java
@@ -39,16 +39,4 @@ public class ManagedRuleProvider extends DefaultAbstractManagedProvider<Rule, St
         return key;
     }
 
-    // @Override
-    // public void addProviderChangeListener(ProviderChangeListener<Rule> listener) {
-    // // TODO Auto-generated method stub
-    //
-    // }
-    //
-    // @Override
-    // public void removeProviderChangeListener(ProviderChangeListener<Rule> listener) {
-    // // TODO Auto-generated method stub
-    //
-    // }
-
 }


### PR DESCRIPTION
The PR fix issue #84.
 https://github.com/marinmitev/smarthome/issues/84
