### PR TITLE
storage service in integration tests independent of execution order

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.integration.test/src/test/groovy/org/eclipse/smarthome/automation/integration/test/AutomationIntegrationJsonTest.groovy
+++ b/bundles/automation/org.eclipse.smarthome.automation.integration.test/src/test/groovy/org/eclipse/smarthome/automation/integration/test/AutomationIntegrationJsonTest.groovy
@@ -59,7 +59,7 @@ class AutomationIntegrationJsonTest extends OSGiTest{
     def ItemRegistry itemRegistry
     def RuleRegistry ruleRegistry
     def Event ruleEvent
-    static def VolatileStorageService volatileStorageService = new VolatileStorageService()//keep storage with rules imported from json files
+    public static def VolatileStorageService VOLATILE_STORAGE_SERVICE = new VolatileStorageService()//keep storage with rules imported from json files
 
     @Before
     void before() {
@@ -137,7 +137,7 @@ class AutomationIntegrationJsonTest extends OSGiTest{
 
 
     protected void registerVolatileStorageService() {
-        registerService(volatileStorageService);
+        registerService(VOLATILE_STORAGE_SERVICE);
     }
 
 
@@ -188,7 +188,7 @@ class AutomationIntegrationJsonTest extends OSGiTest{
             Rule r = ruleRegistry.get("ItemSampleRule")
             assertThat r, is(notNullValue())
             assertThat ruleRegistry.getStatus(r.UID).getStatus(), is(RuleStatus.IDLE)
-            
+
         }, 3000, 200)
         SwitchItem myPresenceItem = itemRegistry.getItem("myPresenceItem")
         eventPublisher.post(ItemEventFactory.createCommandEvent("myPresenceItem", OnOffType.ON))

--- a/bundles/automation/org.eclipse.smarthome.automation.integration.test/src/test/groovy/org/eclipse/smarthome/automation/integration/test/AutomationIntegrationTest.groovy
+++ b/bundles/automation/org.eclipse.smarthome.automation.integration.test/src/test/groovy/org/eclipse/smarthome/automation/integration/test/AutomationIntegrationTest.groovy
@@ -130,6 +130,10 @@ class AutomationIntegrationTest extends OSGiTest{
         logger.info('@After');
     }
 
+    protected void registerVolatileStorageService() {
+        registerService(AutomationIntegrationJsonTest.VOLATILE_STORAGE_SERVICE);
+    }
+
     @Test
     public void 'assert that a rule can be added, updated and removed by the api' () {
         logger.info('assert that a rule can be added, updated and removed by the api');
@@ -553,7 +557,7 @@ class AutomationIntegrationTest extends OSGiTest{
         })
 
     }
-    
+
     @Test
     public void 'assert that a rule created from a more complex template is executed as expected' () {
         logger.info('assert that a rule created from a more complex template is executed as expected');


### PR DESCRIPTION
The execution order of unit tests is not guaranteed. Unfortunately, the automation integration tests were executions in a different order on our jenkins. 

I keep the current hack with the static VolatileStorageService as it is, just extended it to the other test class.

Signed-off-by: Simon Kaufmann simon.kfm@googlemail.com
